### PR TITLE
bugfix: migrates storage to in-memory solution

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import { EXTENSION_NAME } from "./const/extension";
 import { DecorationManager } from "./decoration-manager";
 import { Storage } from "./storage";
 import { SVN } from "./svn";
+import { DecorationRecord } from "./types/decoration-record.model";
 import { debounce } from "./util/debounce";
 
 export async function activate(context: ExtensionContext) {
@@ -12,12 +13,12 @@ export async function activate(context: ExtensionContext) {
         log: true,
     });
     const decorationManager = new DecorationManager();
-    const storage = new Storage(context);
+    const storage = new Storage<DecorationRecord>();
     const svn = new SVN(logger);
     const blamer = new Blamer(logger, storage, svn, decorationManager);
 
     logger.clear();
-    await blamer.clearRecordsForAllFiles();
+    blamer.clearRecordsForAllFiles();
 
     logger.info("Blamer initialised");
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,26 +1,19 @@
-import { ExtensionContext } from "vscode";
+export class Storage<T> {
+    private storage: Map<string, T> = new Map();
 
-export class Storage {
-    constructor(private context: ExtensionContext) {}
-
-    async get<T>(key: string) {
-        return this.context.workspaceState.get<T>(key);
+    get(key: string): T | undefined {
+        return this.storage.get(key);
     }
 
-    async getKeys() {
-        return await this.context.workspaceState.keys();
+    set(key: string, value: T): void {
+        this.storage.set(key, value);
     }
 
-    async set<T>(key: string, value: T) {
-        return this.context.workspaceState.update(key, value);
+    delete(key: string): void {
+        this.storage.delete(key);
     }
 
-    async delete(key: string) {
-        return this.context.workspaceState.update(key, undefined);
-    }
-
-    async clear() {
-        const keys = await this.getKeys();
-        return Promise.all(keys.map((key) => this.context.workspaceState.update(key, undefined)));
+    clear(): void {
+        this.storage.clear();
     }
 }

--- a/src/svn.ts
+++ b/src/svn.ts
@@ -56,7 +56,7 @@ export class SVN {
 
             return mapBlameOutputToBlameModel(data);
         } catch (err: any) {
-            this.logger.error("Failed to blame file", { err });
+            this.logger.error("Failed to blame file", { err: err?.toString() });
             throw err;
         }
     }
@@ -72,7 +72,7 @@ export class SVN {
             });
             return mapLogOutputToMessage(data);
         } catch (err: any) {
-            this.logger.error("Failed to get revision log", { err });
+            this.logger.error("Failed to get revision log", { err: err?.toString() });
             throw err;
         }
     }


### PR DESCRIPTION
This PR fixes #502.

The extension was originally using VS Code's built-in [storage utility](https://code.visualstudio.com/api/references/vscode-api#Memento). However, data is stringified when stored, meaning that our stored decorations were losing their `dispose` method. 

This fix migrates away from this system, instead using an in-memory approach.
It also stringifies errors so that we can hopefully better understand issues in the log output channel.